### PR TITLE
ELPP-3623 Add Vault daemon

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+elifeFormula('master-server')

--- a/README.md
+++ b/README.md
@@ -10,3 +10,48 @@ See the eLife [builder example project](https://github.com/elifesciences/builder
 for a reference on how to integrate with the `builder` project.
 
 [MIT licensed](LICENCE.txt)
+
+## Vault useful commands
+
+Disables TLS locally:
+
+```
+$ export VAULT_ADDR=http://127.0.0.1:8200
+```
+
+Initialization is necessary after the first installation. We are  using a simple single key setup rather than splitting the key with multiple people:
+
+```
+$ vault operator init -key-shares=1 -key-threshold=1 # store the output!
+```
+
+Unsealing will be necessary after any reboot or restart of the vault daemon, as data is encrypted at rest:
+
+```
+$ vault operator unseal ... # unseal key printed during init
+```
+
+Authentication is necessary from the point of view of a user to access a secret:
+
+```
+$ vault login
+# (insert a valid token)
+```
+
+The token can just be the root token generated during initialization, but finer grained tokens can be issued.
+
+Write or read a secret:
+
+```
+$ vault kv put secret/hello foo=world
+$ vault kv get secret/hello
+```
+
+Resetting Vault will lose all stored secrets, but it's useful during local troubleshooting and exemplifies where state is stored:
+
+```
+$ sudo su
+# systemctl stop vault
+# rm -r /var/lib/vault/*
+# systemctl start vault
+```

--- a/salt/example.top
+++ b/salt/example.top
@@ -1,5 +1,6 @@
 base:
     '*':
         - elife
+        - elife.certificates
         - master-server
         - master-server.vault

--- a/salt/example.top
+++ b/salt/example.top
@@ -2,3 +2,4 @@ base:
     '*':
         - elife
         - master-server
+        - master-server.vault

--- a/salt/master-server/config/etc-ubr-vault-backup.yaml
+++ b/salt/master-server/config/etc-ubr-vault-backup.yaml
@@ -1,0 +1,2 @@
+tar-gzipped:
+    - /var/lib/vault

--- a/salt/master-server/config/etc-vault.hcl
+++ b/salt/master-server/config/etc-vault.hcl
@@ -1,0 +1,13 @@
+backend "file" {
+    path = "/var/lib/vault"
+}
+
+disable_mlock=true
+
+# TODO: setup TLS using our wildcard certificate 
+# (fallback to no TLS in Vagrant)
+listener "tcp" {
+    tls_disable = 1
+    #tls_cert_file = "/etc/letsencrypt/live/example.com/fullchain.pem"
+    #tls_key_file = "/etc/letsencrypt/live/example.com/privkey.pem"
+}

--- a/salt/master-server/config/etc-vault.hcl
+++ b/salt/master-server/config/etc-vault.hcl
@@ -4,10 +4,12 @@ backend "file" {
 
 disable_mlock=true
 
-# TODO: setup TLS using our wildcard certificate 
-# (fallback to no TLS in Vagrant)
 listener "tcp" {
+{% if salt['elife.cfg']('cfn.outputs.DomainName') %}
+    tls_disable = 0
+    tls_cert_file = "/etc/certificates/certificate.crt"
+    tls_key_file = "/etc/certificates/privkey.pem"
+{% else %}
     tls_disable = 1
-    #tls_cert_file = "/etc/letsencrypt/live/example.com/fullchain.pem"
-    #tls_key_file = "/etc/letsencrypt/live/example.com/privkey.pem"
+{% endif %}
 }

--- a/salt/master-server/config/lib-systemd-system-vault.service
+++ b/salt/master-server/config/lib-systemd-system-vault.service
@@ -1,0 +1,18 @@
+[Unit]
+Description="vault, serving secrets to developers and instances"
+Documentation=https://vaultproject.io/docs/
+After=network.target
+ConditionFileNotEmpty=/etc/vault.hcl
+
+[Install]
+WantedBy=multi-user.target
+
+[Service]
+# TODO: possibly lock down with:
+# https://www.digitalocean.com/community/tutorials/how-to-securely-manage-secrets-with-hashicorp-vault-on-ubuntu-16-04
+Restart=on-failure
+ExecStart=/usr/local/bin/vault server -config=/etc/vault.hcl
+ExecReload=/usr/local/bin/kill --signal HUP $MAINPID
+User=vault
+Group=vault
+KillSignal=SIGINT

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -8,9 +8,19 @@ vault-binary:
         - source: https://releases.hashicorp.com/vault/{{ vault_version }}/{{ vault_archive }}
         - source_hash: md5={{ vault_hash }}
 
-    cmd.run:
-        - name: unzip {{ vault_archive }} && mv vault /usr/local/bin/vault
-        - cwd: /root
+    archive.extracted:
+        - name: /opt/vault/
+        - source: /root/{{ vault_archive }}
+        - enforce_toplevel: False
+        - require:
+            - file: vault-binary
+
+vault-symlink:
+    file.symlink:
+        - name: /usr/local/bin/vault
+        - target: /opt/vault/vault
+        - require:
+            - vault-binary
 
 vault-user:
     user.present: 
@@ -43,6 +53,7 @@ vault-systemd:
         - template: jinja
         - require:
             - vault-binary
+            - vault-symlink
             - vault-folder
             - vault-configuration
 
@@ -55,3 +66,5 @@ vault-systemd:
         - name: vault
         - require:
             - cmd: vault-systemd
+
+# TODO: add VAULT_ADDR

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -83,3 +83,11 @@ vault-smoke-test:
     cmd.run:
         - name: vault status | grep Sealed
         - user: {{ pillar.elife.deploy_user.username }}
+
+vault-backup:
+    file.managed:
+        - name: /etc/ubr/vault-backup.yaml
+        - source: salt://master-server/config/etc-ubr-vault-backup.yaml
+        - makedirs: True
+        - require:
+            - install-ubr

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -1,0 +1,69 @@
+## Vault useful commands
+##
+## Disables TLS locally;
+## $ export VAULT_ADDR=http://127.0.0.1:8200
+##
+## Initialization
+## $ vault operator init -key-shares=1 -key-threshold=1
+## $ vault unseal ... # unseal key printed during init
+##
+## Resetting (losing all stored secrets)
+## $ systemctl stop vault
+## $
+
+{% set vault_version = '0.10.1' %}
+{% set vault_hash = 'f53ccc280650fed38a10e08c31565e9e' %}
+{% set vault_archive = 'vault_' + vault_version + '_linux_amd64.zip' %}
+vault-binary:
+    file.managed:
+        - name: /root/{{ vault_archive }}
+        - source: https://releases.hashicorp.com/vault/{{ vault_version }}/{{ vault_archive }}
+        - source_hash: md5={{ vault_hash }}
+
+    cmd.run:
+        - name: unzip {{ vault_archive }} && mv vault /usr/local/bin/vault
+        - cwd: /root
+
+vault-user:
+    user.present: 
+        - name: vault
+        - shell: /bin/false
+
+vault-folder:
+    file.directory:
+        - name: /var/lib/vault
+        - user: vault
+        - group: vault
+        - mode: 750
+        - require:
+            - vault-user
+
+vault-configuration:
+    file.managed:
+        - name: /etc/vault.hcl 
+        - source: salt://master-server/config/etc-vault.hcl
+        - user: vault
+        - group: vault
+        - mode: 640
+        - require:
+            - vault-user
+
+vault-systemd:
+    file.managed:
+        - name: /lib/systemd/system/vault.service
+        - source: salt://master-server/config/lib-systemd-system-vault.service
+        - template: jinja
+        - require:
+            - vault-binary
+            - vault-folder
+            - vault-configuration
+
+    cmd.run:
+        - name: systemctl daemon-reload
+        - require:
+            - file: vault-systemd
+
+    service.running:
+        - name: vault
+        - require:
+            - cmd: vault-systemd

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -1,4 +1,3 @@
-
 {% set vault_version = '0.10.1' %}
 {% set vault_hash = 'f53ccc280650fed38a10e08c31565e9e' %}
 {% set vault_archive = 'vault_' + vault_version + '_linux_amd64.zip' %}

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -39,6 +39,7 @@ vault-configuration:
     file.managed:
         - name: /etc/vault.hcl 
         - source: salt://master-server/config/etc-vault.hcl
+        - template: jinja
         - user: vault
         - group: vault
         - mode: 640
@@ -66,7 +67,7 @@ vault-systemd:
         - require:
             - cmd: vault-systemd
 
-{% if salt['elife.only_on_aws']() %}
+{% if salt['elife.cfg']('cfn.outputs.DomainName') %}
 {% set vault_addr = 'https://$(hostname):8200' %}
 {% else %}
 {% set vault_addr = 'http://localhost:8200' %}

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -67,4 +67,19 @@ vault-systemd:
         - require:
             - cmd: vault-systemd
 
-# TODO: add VAULT_ADDR
+{% if salt['elife.only_on_aws']() %}
+{% set vault_addr = 'https://$(hostname):8200' %}
+{% else %}
+{% set vault_addr = 'http://localhost:8200' %}
+{% endif %}
+vault-cli-client-environment-configuration:
+    file.managed:
+        - name: /etc/profile.d/vault-client.sh
+        - contents: export VAULT_ADDR={{ vault_addr }}
+        - template: jinja
+        - mode: 644
+
+vault-smoke-test:
+    cmd.run:
+        - name: vault status | grep Sealed
+        - user: {{ pillar.elife.deploy_user.username }}

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -1,15 +1,3 @@
-## Vault useful commands
-##
-## Disables TLS locally;
-## $ export VAULT_ADDR=http://127.0.0.1:8200
-##
-## Initialization
-## $ vault operator init -key-shares=1 -key-threshold=1
-## $ vault unseal ... # unseal key printed during init
-##
-## Resetting (losing all stored secrets)
-## $ systemctl stop vault
-## $
 
 {% set vault_version = '0.10.1' %}
 {% set vault_hash = 'f53ccc280650fed38a10e08c31565e9e' %}

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -79,11 +79,11 @@ vault-cli-client-environment-configuration:
         - template: jinja
         - mode: 644
 
-# smoke test fails if `vault operator init` has not been run
-# have to find another smoke test, as that operation outputs sensitive unseal keys and master tokens that a human needs to collect
+# vault initialization requires a human, so the only thing we
+# can check on the first highstate is that a daemon is listening
 vault-smoke-test:
     cmd.run:
-        - name: vault status | grep Sealed
+        - name: nc -q0 -w1 -z localhost 8200
         - user: {{ pillar.elife.deploy_user.username }}
 
 vault-backup:

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -79,6 +79,8 @@ vault-cli-client-environment-configuration:
         - template: jinja
         - mode: 644
 
+# smoke test fails if `vault operator init` has not been run
+# have to find another smoke test, as that operation outputs sensitive unseal keys and master tokens that a human needs to collect
 vault-smoke-test:
     cmd.run:
         - name: vault status | grep Sealed


### PR DESCRIPTION
As for the relevant ticket, Fastly and Google Cloud Platform credentials could be stored here for the developers benefits. Since we already have a `master-server` full of credentials, it simplifies locking it down. This is a very basic setup.

Looking more for the long term, we could even try moving some of the pillar secrets into Vault as an [external pillar](https://docs.saltstack.com/en/develop/ref/pillar/all/salt.pillar.vault.html); that's not the main point at the moment.