### PR TITLE
fix, ubr backup descriptor uses glob syntax

### DIFF
--- a/salt/master-server/config/etc-ubr-vault-backup.yaml
+++ b/salt/master-server/config/etc-ubr-vault-backup.yaml
@@ -1,2 +1,2 @@
 tar-gzipped:
-    - /var/lib/vault
+    - /var/lib/vault/**

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -24,6 +24,8 @@ vault-symlink:
 vault-user:
     user.present: 
         - name: vault
+        - groups:
+            - vault
         - shell: /bin/false
 
 vault-folder:
@@ -83,7 +85,7 @@ vault-cli-client-environment-configuration:
 # can check on the first highstate is that a daemon is listening
 vault-smoke-test:
     cmd.run:
-        - name: nc -q0 -w1 -z localhost 8200
+        - name: wait_for_port 8200 10
         - user: {{ pillar.elife.deploy_user.username }}
 
 vault-backup:


### PR DESCRIPTION
yeah, yeah, I know

fyi @giorgiosironi 

