### PR TITLE
Salt pillars and Vault integration

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -4,3 +4,4 @@ base:
         - elife.certificates
         - master-server
         - master-server.vault
+        - master-server.salt-vault

--- a/salt/master-server/config/etc-salt-master.d-peer_run.conf
+++ b/salt/master-server/config/etc-salt-master.d-peer_run.conf
@@ -1,0 +1,4 @@
+# allows Vault tokens to be generated for minions
+peer_run:
+    .*:
+        - vault.generate_token

--- a/salt/master-server/config/etc-salt-master.d-vault.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault.conf
@@ -4,5 +4,4 @@ vault:
         method: token
         token: {{ pillar.master_server.vault.access_token }}
     policies:
-        # this will need attention, but the Salt master already has access to the whole of builder-private so it makes sense
-        - root
+        - {{ pillar.master_server.vault.policy }}

--- a/salt/master-server/config/etc-salt-master.d-vault.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault.conf
@@ -6,5 +6,5 @@ vault:
     policies:
         # this will need attention
         - default
-        - saltstack/minions
-        - saltstack/minion/{minion}
+        #- saltstack/minions
+        #- saltstack/minion/{minion}

--- a/salt/master-server/config/etc-salt-master.d-vault.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault.conf
@@ -1,5 +1,5 @@
 vault:
-    url: http://localhost:8200
+    url: {{ vault_addr }}
     auth:
         method: token
         token: {{ pillar.master_server.vault.access_token }}

--- a/salt/master-server/config/etc-salt-master.d-vault.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault.conf
@@ -4,7 +4,5 @@ vault:
         method: token
         token: {{ pillar.master_server.vault.access_token }}
     policies:
-        # this will need attention
-        - default
-        #- saltstack/minions
-        #- saltstack/minion/{minion}
+        # this will need attention, but the Salt master already has access to the whole of builder-private so it makes sense
+        - root

--- a/salt/master-server/config/etc-salt-master.d-vault.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault.conf
@@ -1,0 +1,10 @@
+vault:
+    url: http://localhost:8200
+    auth:
+        method: token
+        token: {{ pillar.master_server.vault.access_token }}
+    policies:
+        # this will need attention
+        - default
+        - saltstack/minions
+        - saltstack/minion/{minion}

--- a/salt/master-server/config/etc-salt-master.d-vault.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault.conf
@@ -4,4 +4,7 @@ vault:
         method: token
         token: {{ pillar.master_server.vault.access_token }}
     policies:
-        - {{ pillar.master_server.vault.policy }}
+        - default
+        # there is no elife_project or elife_environment grain yet
+        #- project/{elife_project}
+        #- project/{elife_project}/{elife_environment}

--- a/salt/master-server/config/etc-salt-master.d-vault_ext_pillar.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault_ext_pillar.conf
@@ -1,0 +1,4 @@
+pillar_roots:
+    ext_pillar:
+      - vault: path=secret/elife
+      - vault: path=secret/projects/{grains[elife_project]}

--- a/salt/master-server/config/etc-salt-master.d-vault_ext_pillar.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault_ext_pillar.conf
@@ -1,4 +1,3 @@
-pillar_roots:
-    ext_pillar:
-      - vault: path=secret/elife
-      - vault: path=secret/projects/{grains[elife_project]}
+ext_pillar:
+    - vault: path=secret/elife
+    - vault: path=secret/projects/{grains[elife_project]}

--- a/salt/master-server/config/etc-salt-master.d-vault_ext_pillar.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault_ext_pillar.conf
@@ -1,3 +1,4 @@
 ext_pillar:
     - vault: path=secret/elife
-    - vault: path=secret/projects/{grains[elife_project]}
+    # there is no elife_project grain yet
+    #- vault: path=secret/projects/{grains[elife_project]}

--- a/salt/master-server/config/lib-systemd-system-vault.service
+++ b/salt/master-server/config/lib-systemd-system-vault.service
@@ -11,7 +11,7 @@ WantedBy=multi-user.target
 # TODO: possibly lock down with:
 # https://www.digitalocean.com/community/tutorials/how-to-securely-manage-secrets-with-hashicorp-vault-on-ubuntu-16-04
 Restart=on-failure
-ExecStart=/usr/local/bin/vault server {% if not pillar.elife.env in ['dev', 'ci'] %}-config=/etc/vault.hcl{% else %}-dev{% endif %}
+ExecStart=/usr/local/bin/vault server {% if pillar.elife.env != 'dev' %}-config=/etc/vault.hcl{% else %}-dev{% endif %}
 ExecReload=/usr/local/bin/kill --signal HUP $MAINPID
 User=vault
 Group=vault

--- a/salt/master-server/config/lib-systemd-system-vault.service
+++ b/salt/master-server/config/lib-systemd-system-vault.service
@@ -11,7 +11,7 @@ WantedBy=multi-user.target
 # TODO: possibly lock down with:
 # https://www.digitalocean.com/community/tutorials/how-to-securely-manage-secrets-with-hashicorp-vault-on-ubuntu-16-04
 Restart=on-failure
-ExecStart=/usr/local/bin/vault server -config=/etc/vault.hcl
+ExecStart=/usr/local/bin/vault server {% if not pillar.elife.env in ['dev', 'ci'] %}-config=/etc/vault.hcl{% else %}-dev{% endif %}
 ExecReload=/usr/local/bin/kill --signal HUP $MAINPID
 User=vault
 Group=vault

--- a/salt/master-server/salt-vault.sls
+++ b/salt/master-server/salt-vault.sls
@@ -2,12 +2,8 @@ salt-vault-config:
     file.managed:
         - name: /etc/salt/master.d/vault.conf
         - source: salt://master-server/config/etc-salt-master.d-vault.conf
-        - watch_in:
-            - service: vault-systemd
 
 salt-vault-peer-runner-conf:
     file.managed:
         - name: /etc/salt/master.d/peer_run.conf
         - source: salt://master-server/config/etc-salt-master.d-peer_run.conf
-        - watch_in:
-            - service: vault-systemd

--- a/salt/master-server/salt-vault.sls
+++ b/salt/master-server/salt-vault.sls
@@ -1,10 +1,23 @@
+{% if salt['elife.cfg']('cfn.outputs.DomainName') %}
+    {% set vault_addr = 'https://$(hostname):8200' %}
+{% else %}
+    {% set vault_addr = 'http://localhost:8200' %}
+{% endif %}
+
 salt-vault-config:
     file.managed:
         - name: /etc/salt/master.d/vault.conf
         - source: salt://master-server/config/etc-salt-master.d-vault.conf
         - template: jinja
+        - defaults:
+            vault_addr: {{ vault_addr }}
 
 salt-vault-peer-runner-conf:
     file.managed:
         - name: /etc/salt/master.d/peer_run.conf
         - source: salt://master-server/config/etc-salt-master.d-peer_run.conf
+
+salt-vault-ext-pillars:
+    file.managed:
+        - name: /etc/salt/master.d/vault_ext_pillar
+        - source: salt://master-server/config/etc-salt-master.d-vault_ext_pillar.conf

--- a/salt/master-server/salt-vault.sls
+++ b/salt/master-server/salt-vault.sls
@@ -1,0 +1,13 @@
+salt-vault-config:
+    file.managed:
+        - name: /etc/salt/master.d/vault.conf
+        - source: salt://master-server/config/etc-salt-master.d-vault.conf
+        - watch_in:
+            - service: vault-systemd
+
+salt-vault-peer-runner-conf:
+    file.managed:
+        - name: /etc/salt/master.d/peer_run.conf
+        - source: salt://master-server/config/etc-salt-master.d-peer_run.conf
+        - watch_in:
+            - service: vault-systemd

--- a/salt/master-server/salt-vault.sls
+++ b/salt/master-server/salt-vault.sls
@@ -2,6 +2,7 @@ salt-vault-config:
     file.managed:
         - name: /etc/salt/master.d/vault.conf
         - source: salt://master-server/config/etc-salt-master.d-vault.conf
+        - template: jinja
 
 salt-vault-peer-runner-conf:
     file.managed:

--- a/salt/master-server/salt-vault.sls
+++ b/salt/master-server/salt-vault.sls
@@ -19,5 +19,5 @@ salt-vault-peer-runner-conf:
 
 salt-vault-ext-pillars:
     file.managed:
-        - name: /etc/salt/master.d/vault_ext_pillar
+        - name: /etc/salt/master.d/vault_ext_pillar.conf
         - source: salt://master-server/config/etc-salt-master.d-vault_ext_pillar.conf

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -69,7 +69,7 @@ vault-systemd:
         - require:
             - cmd: vault-systemd
 
-{% if salt['elife.cfg']('cfn.outputs.DomainName') %}
+{% if not pillar.elife.env in ['dev', 'ci'] %}
 {% set vault_addr = 'https://$(hostname):8200' %}
 {% else %}
 {% set vault_addr = 'http://localhost:8200' %}

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -69,7 +69,7 @@ vault-systemd:
         - require:
             - cmd: vault-systemd
 
-{% if not pillar.elife.env in ['dev', 'ci'] %}
+{% if pillar.elife.env != 'dev' %}
 {% set vault_addr = 'https://$(hostname):8200' %}
 {% else %}
 {% set vault_addr = 'http://localhost:8200' %}

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -1,5 +1,5 @@
-{% set vault_version = '0.10.1' %}
-{% set vault_hash = 'f53ccc280650fed38a10e08c31565e9e' %}
+{% set vault_version = '0.11.0' %}
+{% set vault_hash = 'ca9316e4864a9585f7c6507e38568053' %}
 {% set vault_archive = 'vault_' + vault_version + '_linux_amd64.zip' %}
 vault-binary:
     file.managed:

--- a/salt/pillar/master-server.sls
+++ b/salt/pillar/master-server.sls
@@ -3,5 +3,7 @@ elife:
         username: vault
 
 master_server:
+    vault:
+        access_token: 11111111-2222-3333-4444-555555555555
     chemist:
         secret: null

--- a/salt/pillar/master-server.sls
+++ b/salt/pillar/master-server.sls
@@ -5,7 +5,5 @@ elife:
 master_server:
     vault:
         access_token: 11111111-2222-3333-4444-555555555555
-        # do not use `root`: Vault has more secrets than Salt needs
-        policy: master-server
     chemist:
         secret: null

--- a/salt/pillar/master-server.sls
+++ b/salt/pillar/master-server.sls
@@ -5,5 +5,7 @@ elife:
 master_server:
     vault:
         access_token: 11111111-2222-3333-4444-555555555555
+        # do not use `root`: Vault has more secrets than Salt needs
+        policy: master-server
     chemist:
         secret: null


### PR DESCRIPTION
Sets up the Salt master integration with Vault running on the same server, through a static token.

Sets up the pillar integration so that pillar values can be read from Vault rather than just from `builder-private. The level of nesting with our Salt version is minimal, they will reside at the top level together with `pilar.elife`.

Minions can generate a subtoken from the Salt master one that limits them to a particular policy, in this case reading only their own project or project+environment secrets.