### PR TITLE
Expand chemist to also update builder-configuration

### DIFF
--- a/salt/master-server/config/opt-chemist-app.conf
+++ b/salt/master-server/config/opt-chemist-app.conf
@@ -1,4 +1,4 @@
 [chemist]
-repositories=.*-formula,.*/builder-private
+repositories=.*-formula,.*/builder-private,.*/builder-configuration
 command=sudo /opt/update-master.sh
 secret={{ pillar.master_server.chemist.secret }}


### PR DESCRIPTION
Little project that updates repositories on Github hooks gets expanded to deal also with builder-configuration

For https://github.com/elifesciences/issues/issues/3691