### PR TITLE
Integrate Vault custom pillars with Salt 2018.3

### DIFF
--- a/salt/master-server/config/etc-salt-master.d-vault.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault.conf
@@ -5,6 +5,9 @@ vault:
     auth:
         method: token
         token: {{ token }} 
-    # minion-related policies: we don't need them to access anything directly
     policies:
         - default
+        # since Salt 2018.3.4 the token is used to create children tokens for each minion
+        # https://github.com/saltstack/salt/commit/b0ba2ecfae9b119fd66fde99c3f31f5ff38ef3ae#diff-e75b02a233b726e8be8f614a7a554fd5
+        # the easiest step is to replicate this token's permissions in the children
+        - master-server

--- a/salt/master-server/config/opt-salt-extension-modules-pillar-elife_vault.py
+++ b/salt/master-server/config/opt-salt-extension-modules-pillar-elife_vault.py
@@ -47,7 +47,7 @@ def ext_pillar(minion_id, pillar, path=None, env_key=None):
     try:
         vault_value = __salt__['vault.read_secret'](vault_key)
     except Exception as e:
-        log.warn("Error accessing Vault (%s): %s", type(e), str(e))
+        log.warning("Error accessing Vault (%s): %s", type(e), str(e))
         return {}
 
     return _expand_vault_pillar(vault_value['data'])

--- a/salt/master-server/vault-policies/master-server.hcl
+++ b/salt/master-server/vault-policies/master-server.hcl
@@ -9,3 +9,7 @@ path "secret/data/projects/*" {
 path "secret/data/projects/" {
     capabilities = ["list"]
 }
+
+path "auth/token/create" {
+    capabilities = ["create", "update"]
+}


### PR DESCRIPTION
- Allow `master-server` token to create children tokens
- Add `master-server` to minion Vault policies