### PR TITLE
Declare Vault dependent projects

### DIFF
--- a/salt/master-server/config/etc-salt-master.d-vault_ext_pillar.conf
+++ b/salt/master-server/config/etc-salt-master.d-vault_ext_pillar.conf
@@ -3,3 +3,4 @@ ext_pillar:
     - elife_vault:
          path: secret/data/projects/{project}/{env}
          env_key: ["elife", "env"]
+         dependent_projects: {{ pillar.master_server.vault.dependent_projects }}

--- a/salt/master-server/config/opt-salt-extension-modules-pillar-elife_vault.py
+++ b/salt/master-server/config/opt-salt-extension-modules-pillar-elife_vault.py
@@ -51,10 +51,10 @@ def ext_pillar(minion_id, pillar, path=None, env_key=None, dependent_projects=No
         vault_value = __salt__['vault.read_secret'](vault_key)
     except Exception as e:
         if project in dependent_projects:
-            log.warning("Error accessing Vault (%s) in dependent project %s: %s", project, type(e), str(e))
+            log.critical("Error accessing Vault (%s) in dependent project %s: %s", project, type(e), str(e))
             raise e
         else:
-            log.warning("Error accessing Vault (%s): %s", type(e), str(e))
+            log.warning("Error accessing Vault (%s) in project %s, skipping its pillars: %s", project, type(e), str(e))
             return {}
 
     return _expand_vault_pillar(vault_value['data'])

--- a/salt/master-server/config/opt-salt-extension-modules-pillar-elife_vault.py
+++ b/salt/master-server/config/opt-salt-extension-modules-pillar-elife_vault.py
@@ -53,9 +53,9 @@ def ext_pillar(minion_id, pillar, path=None, env_key=None, dependent_projects=No
         if project in dependent_projects:
             log.critical("Error accessing Vault (%s) in dependent project %s: %s", project, type(e), str(e))
             raise e
-        else:
-            log.warning("Error accessing Vault (%s) in project %s, skipping its pillars: %s", project, type(e), str(e))
-            return {}
+
+        log.warning("Error accessing Vault (%s) in project %s, skipping its pillars: %s", project, type(e), str(e))
+        return {}
 
     return _expand_vault_pillar(vault_value['data'])
 

--- a/salt/pillar/master-server.sls
+++ b/salt/pillar/master-server.sls
@@ -5,3 +5,6 @@ elife:
 master_server:
     chemist:
         secret: null
+    vault:
+        dependent_projects:
+            - basebox


### PR DESCRIPTION
For https://github.com/elifesciences/issues/issues/5002

If these projects do not have access to a readable Vault key for secrets, their highstate should fail hard.