### PR TITLE
Deploy a nothing service to port 80 so that ACME http challenge can succeed 

### DIFF
--- a/salt/master-server/config/etc-caddy-sites.d-vault.conf
+++ b/salt/master-server/config/etc-caddy-sites.d-vault.conf
@@ -11,6 +11,10 @@
     }
 }
 
+:80 {
+    respond "Hello" 200
+}
+
 {% if salt['elife.cfg']('cfn.outputs.DomainName') %}
 https://{{ salt['elife.cfg']('cfn.outputs.DomainName') }}:8201 {
     import ../snippets/certs


### PR DESCRIPTION
elifesciences/issues#9172