### PR TITLE
Switch Caddy as frontend server proxy for vault

### DIFF
--- a/salt/master-server/config/etc-caddy-sites.d-vault.conf
+++ b/salt/master-server/config/etc-caddy-sites.d-vault.conf
@@ -7,7 +7,7 @@
     }
 
     handle {
-        reverse_proxy https://localhost:8200
+        reverse_proxy http://localhost:8201
     }
 }
 
@@ -16,7 +16,7 @@
 }
 
 {% if salt['elife.cfg']('cfn.outputs.DomainName') %}
-https://{{ salt['elife.cfg']('cfn.outputs.DomainName') }}:8201, https://master-server.elifesciences.org:8201 {
+https://{{ salt['elife.cfg']('cfn.outputs.DomainName') }}:8200, https://master-server.elifesciences.org:8200 {
     import ../snippets/certs
     import config
 }

--- a/salt/master-server/config/etc-caddy-sites.d-vault.conf
+++ b/salt/master-server/config/etc-caddy-sites.d-vault.conf
@@ -11,13 +11,19 @@
     }
 }
 
+
+{% if pillar.elife.env != 'dev' %}
 :80 {
     respond "Hello" 200
 }
-
 {% if salt['elife.cfg']('cfn.outputs.DomainName') %}
 https://{{ salt['elife.cfg']('cfn.outputs.DomainName') }}:8200, https://master-server.elifesciences.org:8200 {
     import ../snippets/certs
+    import config
+}
+{% endif %}
+{% else %}
+:8200 {
     import config
 }
 {% endif %}

--- a/salt/master-server/config/etc-vault.hcl
+++ b/salt/master-server/config/etc-vault.hcl
@@ -5,14 +5,8 @@ backend "file" {
 disable_mlock=true
 
 listener "tcp" {
-    address = "0.0.0.0:8200"
-{% if salt['elife.cfg']('cfn.outputs.DomainName') %}
-    tls_disable = false
-    tls_cert_file = "/etc/certificates/certificate.chained.crt"
-    tls_key_file = "/etc/certificates/privkey.pem"
-{% else %}
+    address = "127.0.0.1:8201"
     tls_disable = true
-{% endif %}
 }
 
 # https://hostname.org:8200/ui/

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -81,12 +81,12 @@ vault-systemd:
         - enable: True
         - require:
             - cmd: vault-systemd
+        - onchanges:
+            - vault-configuration
+
         # restart vault service when certificates change
         # certificates not present in dev environments
-        - watch:
-            - vault-configuration
         {% if pillar.elife.env != 'dev' %}
-        - onchanges:
             # the two files references in /etc/vault.hcl
             # they're only modified when the certificate is regenerated
             - etc-certificates-fullchain-key

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -230,7 +230,7 @@ vault-caddy-ready:
         - require:
             - vault-bootstrap-smoke-test
         - watch:
-            service: vault-systemd
+            - service: vault-systemd
         - require_in:
             - caddy-validate-config
         # reload caddy if the configuration has changed

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -83,6 +83,8 @@ vault-systemd:
             - cmd: vault-systemd
         # restart vault service when certificates change
         # certificates not present in dev environments
+        - watch:
+            - vault-configuration
         {% if pillar.elife.env != 'dev' %}
         - onchanges:
             # the two files references in /etc/vault.hcl

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -173,6 +173,7 @@ vault-unseal:
         - require:
             - vault-init
             - unseal-vault-script
+            - vault-caddy-ready
         - env:
             - VAULT_ADDR: {{ vault_addr }}
 
@@ -224,7 +225,7 @@ vault-caddy-ready:
         - source: salt://master-server/config/etc-caddy-sites.d-vault.conf
         - template: jinja
         - require:
-            - vault-unseal
+            - vault-init
         - require_in:
             - caddy-validate-config
         # reload caddy if the configuration has changed

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -237,6 +237,14 @@ vault-caddy-ready:
         - watch_in:
             - service: caddy-server-service
 
+debug_caddy:
+  cmd.run:
+    - name: |
+        systemctl status caddy.service
+        journalctl -xeu caddy --no-pager
+    - onfail:
+      - service: caddy-server-service
+
 # ---
 
 {% if False %}

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -229,6 +229,8 @@ vault-caddy-ready:
         - template: jinja
         - require:
             - vault-bootstrap-smoke-test
+        - watch:
+            service: vault-systemd
         - require_in:
             - caddy-validate-config
         # reload caddy if the configuration has changed

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -81,7 +81,7 @@ vault-systemd:
         - enable: True
         - require:
             - cmd: vault-systemd
-        - onchanges:
+        - watch:
             - vault-configuration
 
         # restart vault service when certificates change

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -247,14 +247,6 @@ vault-caddy-smoke-test:
             - vault-caddy-ready
             - service: caddy-server-service
 
-debug_caddy:
-  cmd.run:
-    - name: |
-        systemctl status caddy.service
-        journalctl -xeu caddy --no-pager
-    - onfail:
-      - service: caddy-server-service
-
 # ---
 
 {% if False %}

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -159,7 +159,7 @@ vault-init:
             - test -d /var/lib/vault/core
         - require:
             - vault-bootstrap-smoke-test
-            - vault-caddy-ready
+            - vault-caddy-smoke-test
         - env:
             - VAULT_ADDR: {{ vault_addr }}
 
@@ -176,7 +176,7 @@ vault-unseal:
         - require:
             - vault-init
             - unseal-vault-script
-            - vault-caddy-ready
+            - vault-caddy-smoke-test
         - env:
             - VAULT_ADDR: {{ vault_addr }}
 
@@ -235,6 +235,16 @@ vault-caddy-ready:
             - caddy-validate-config
         # reload caddy if the configuration has changed
         - watch_in:
+            - service: caddy-server-service
+
+vault-caddy-smoke-test:
+    cmd.run:
+        - name: |
+            wait_for_port 8200 10
+            curl {{ vault_addr }}
+        - runas: {{ pillar.elife.deploy_user.username }}
+        - require:
+            - vault-caddy-ready
             - service: caddy-server-service
 
 debug_caddy:

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -157,6 +157,7 @@ vault-init:
             - test -d /var/lib/vault/core
         - require:
             - vault-bootstrap-smoke-test
+            - vault-caddy-ready
         - env:
             - VAULT_ADDR: {{ vault_addr }}
 

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -136,7 +136,7 @@ unseal-vault-systemd:
 # can check on the first highstate is that a daemon is listening
 vault-bootstrap-smoke-test:
     cmd.run:
-        - name: wait_for_port 8200 10
+        - name: wait_for_port 8201 10
         - runas: {{ pillar.elife.deploy_user.username }}
         - require:
             - service: vault-systemd

--- a/salt/master-server/vault.sls
+++ b/salt/master-server/vault.sls
@@ -226,7 +226,7 @@ vault-caddy-ready:
         - source: salt://master-server/config/etc-caddy-sites.d-vault.conf
         - template: jinja
         - require:
-            - vault-init
+            - vault-bootstrap-smoke-test
         - require_in:
             - caddy-validate-config
         # reload caddy if the configuration has changed


### PR DESCRIPTION
- Make vault listen to localhost 8201 only
- set caddy as the front server on port 8200, proxy to localhost 8200

elifesciences/issues#9172